### PR TITLE
Make radar and name list default sizes scale with resolution

### DIFF
--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -5,6 +5,10 @@ ADDON = false;
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 #define CBA_SETTINGS_CAT (format ["%1 - %2",localize "STR_dui_mod", localize "STR_dui_addon_radar"])
 
+private _res = getResolution;
+private _height = _res select 1;
+private _saneScale = _height / 1080; // diwako calibrates for 1080p so let's do the same
+
 GVAR(group) = [];
 GVAR(compass_pfHandle) = -1;
 GVAR(namebox_lists) = [];
@@ -230,7 +234,7 @@ private _curCat = localize "STR_dui_cat_namelist";
     ,"SLIDER"
     ,[localize "STR_dui_namelist_size", localize "STR_dui_namelist_size_desc"]
     ,[CBA_SETTINGS_CAT, _curCat]
-    ,[0.5, 3, 1, 3]
+    ,[0.5, 3, _saneScale^1.5, 8]
     ,false
     ,{
         [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
@@ -276,7 +280,7 @@ private _curCat = localize "STR_dui_cat_namelist";
     ,"SLIDER"
     ,[localize "STR_dui_namelist_vertical_spacing", localize "STR_dui_namelist_vertical_spacing_desc"]
     ,[CBA_SETTINGS_CAT, _curCat]
-    ,[0, 5, 1, 3]
+    ,[0, 5, 1/_saneScale, 3]
     ,false
     ,{
         [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
@@ -309,7 +313,7 @@ private _curCat = localize "STR_dui_cat_namelist";
     ,"SLIDER"
     ,[localize "STR_dui_ui_scale", ""]
     ,[CBA_SETTINGS_CAT, localize "STR_dui_cat_general"]
-    ,[0.5, 3, 1, 2]
+    ,[0.5, 3, _saneScale, 2]
     ,false
     ,{
         params ["_value"];

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -5,9 +5,9 @@ ADDON = false;
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 #define CBA_SETTINGS_CAT (format ["%1 - %2",localize "STR_dui_mod", localize "STR_dui_addon_radar"])
 
-private _res = getResolution;
-private _height = _res select 1;
-private _saneScale = _height / 1080; // diwako calibrates for 1080p so let's do the same
+// Scale by the height of the monitor as that's a better indicator of DPI than width.
+// We use 1080p as our reference as that's what diwako calibrated everything on.
+private _saneScale = (getResolution select 1) / 1080; 
 
 GVAR(group) = [];
 GVAR(compass_pfHandle) = -1;


### PR DESCRIPTION
- Radar scales perfectly as far as I can tell
    - Have tested at 1080p, 1440p, and 2160p
- Doesn't override any settings if people have changed them
- Name list doesn't scale as well (it shrinks as the resolution increases) but it's still loads better than it was. 
    - There must be a "right" answer somewhere between `_saneScale^p` where p \in (1.5,2), as with p=2 the list grew with resolution, but I ran out of patience ;)
    - I increased the maximum size to 8 because I suspect it would be tiny on 8K screens, but I'm happy to reduce this if you think it's implausible that anyone will ever play ArmA with a resolution that big.