### PR TITLE
Feature - Sort Namelist Feature

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 5
-#define PATCHLVL 2
-#define BUILD 9
+#define PATCHLVL 3
+#define BUILD 5

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1056,6 +1056,14 @@
             <English>The bearing number will be filled with leading zeroes</English>
             <German>Die Richtungsanzeige wird mit führenden Nullen aufgefüllt</German>
         </Key>
+        <Key ID="STR_dui_radar_sync_groups">
+            <English>Synchronize Groups</English>
+            <German>Gruppen synchronisieren</German>
+        </Key>
+        <Key ID="STR_dui_radar_sync_groups_desc">
+            <English>Server and multiplayer only setting! During multiplayer game play the order of people in the namelist can become asynchronous. This option will synchronize the order of appearance as the server sees them</English>
+            <German>Nur für Server und multiplayer! Während online Partien kann die Reihenfolge der Einheiten in der Namensliste asynchron werden. Mit dieser Option synchronisiert der Server die Reihenfolge der Einheiten, wie dieser diese sieht</German>
+        </Key>
         <!-- Addon module names -->
         <Key ID="STR_dui_addon_main">
             <English>Main</English>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1056,13 +1056,21 @@
             <English>The bearing number will be filled with leading zeroes</English>
             <German>Die Richtungsanzeige wird mit führenden Nullen aufgefüllt</German>
         </Key>
-        <Key ID="STR_dui_radar_sync_groups">
-            <English>Synchronize Groups</English>
-            <German>Gruppen synchronisieren</German>
+        <Key ID="STR_dui_radar_sqlFirst">
+            <English>Show SQL Always First</English>
+            <German>Gruppenführer immer als erster</German>
         </Key>
-        <Key ID="STR_dui_radar_sync_groups_desc">
-            <English>Server and multiplayer only setting! During multiplayer game play the order of people in the namelist can become asynchronous. This option will synchronize the order of appearance as the server sees them</English>
-            <German>Nur für Server und multiplayer! Während online Partien kann die Reihenfolge der Einheiten in der Namensliste asynchron werden. Mit dieser Option synchronisiert der Server die Reihenfolge der Einheiten, wie dieser diese sieht</German>
+        <Key ID="STR_dui_radar_sqlFirst_desc">
+            <English>Shows the squad leader always as first unit</English>
+            <German>Zeigt den Gruppenführer immer als Erster in der Liste an</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort">
+            <English>Sort</English>
+            <German>Sortieren</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort_desc">
+            <English>Server needs to run DUI in order to have synchronicity!</English>
+            <German>Der Server muss DUI geladen haben um Synchronität zu garantieren!</German>
         </Key>
         <!-- Addon module names -->
         <Key ID="STR_dui_addon_main">
@@ -1400,6 +1408,27 @@
             <Portuguese>Interface Militar</Portuguese>
             <!-- <Spanish></Spanish> -->
             <!-- <Russian></Russian> -->
+        </Key>
+        <!-- Sort options -->
+        <Key ID="STR_dui_radar_sort_none">
+            <English>None</English>
+            <German>Kein</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort_name">
+            <English>Names</English>
+            <German>Namen</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort_fireteam">
+            <English>Fire Team, Names</English>
+            <German>Fireteam, Namen</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort_fireteam2">
+            <English>Fire Team, Rank, Names</English>
+            <German>Fireteam, Rang, Namen</German>
+        </Key>
+        <Key ID="STR_dui_radar_sort_rank">
+            <English>Rank, Names</English>
+            <German>Rang, Namen</German>
         </Key>
     </Package>
 </Project>

--- a/addons/radar/XEH_PREP.hpp
+++ b/addons/radar/XEH_PREP.hpp
@@ -4,3 +4,4 @@ PREP(displayUnitOnCompass);
 PREP(getIcon);
 PREP(rangeButton);
 PREP(setCustomCode);
+PREP(syncGroups);

--- a/addons/radar/XEH_PREP.hpp
+++ b/addons/radar/XEH_PREP.hpp
@@ -5,3 +5,4 @@ PREP(getIcon);
 PREP(rangeButton);
 PREP(setCustomCode);
 PREP(syncGroups);
+PREP(sortNameList);

--- a/addons/radar/XEH_postInit.sqf
+++ b/addons/radar/XEH_postInit.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 if (is3DEN) exitWith {};
 
-if (isMultiplayer && {GVAR(syncGroups)}) then {
+if (isMultiplayer && {GVAR(sortType) == "none"}) then {
     call FUNC(syncGroups);
 };
 

--- a/addons/radar/XEH_postInit.sqf
+++ b/addons/radar/XEH_postInit.sqf
@@ -1,19 +1,8 @@
 #include "script_component.hpp"
 if (is3DEN) exitWith {};
 
-if (isMultiplayer) then {
+if (isMultiplayer && {GVAR(syncGroups)}) then {
     call FUNC(syncGroups);
-    if (isServer) then {
-        call GVAR(syncGroupVar);
-    } else {
-        // tell server to run the sync script
-        // only useful if the server itself is not running DUI and is not using battle eye
-        publicVariable QGVAR(syncGroupVar);
-        [0,{
-            waitUntil { !isNil QGVAR(syncGroupVar) };
-            call GVAR(syncGroupVar);
-        }] remoteExec ["spawn", 2];
-    };
 };
 
 if !(hasInterface) exitWith {};

--- a/addons/radar/XEH_postInit.sqf
+++ b/addons/radar/XEH_postInit.sqf
@@ -1,5 +1,21 @@
 #include "script_component.hpp"
-if (is3DEN || !hasInterface) exitWith {};
+if (is3DEN) exitWith {};
+
+if (isMultiplayer) then {
+    if (isServer) then {
+        call FUNC(syncGroups);
+    } else {
+        // tell server to run the sync script
+        // only useful if the server itself is not running DUI and is not using battle eye
+        publicVariableServer QFUNC(syncGroups);
+        [0,{
+            waitUntil { !isNil QFUNC(syncGroups) };
+            call FUNC(syncGroups);
+        }] remoteExec ["spawn", 2];
+    };
+};
+
+if !(hasInterface) exitWith {};
 
 GVAR(uiPixels) = DUI_128PX;
 

--- a/addons/radar/XEH_postInit.sqf
+++ b/addons/radar/XEH_postInit.sqf
@@ -2,15 +2,16 @@
 if (is3DEN) exitWith {};
 
 if (isMultiplayer) then {
+    call FUNC(syncGroups);
     if (isServer) then {
-        call FUNC(syncGroups);
+        call GVAR(syncGroupVar);
     } else {
         // tell server to run the sync script
         // only useful if the server itself is not running DUI and is not using battle eye
-        publicVariableServer QFUNC(syncGroups);
+        publicVariable QGVAR(syncGroupVar);
         [0,{
-            waitUntil { !isNil QFUNC(syncGroups) };
-            call FUNC(syncGroups);
+            waitUntil { !isNil QGVAR(syncGroupVar) };
+            call GVAR(syncGroupVar);
         }] remoteExec ["spawn", 2];
     };
 };

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -359,13 +359,14 @@ GVAR(sortNamespace) setVariable ["COLONEL", 0];
     ,[localize "STR_dui_radar_sort", localize "STR_dui_radar_sort_desc"]
     ,[CBA_SETTINGS_CAT, _curCat]
     ,[
-        ["none", "name", "fireteam", "fireteam2", "rank"],
+        ["none", "name", "fireteam", "fireteam2", "rank", "custom"],
         [
             localize "STR_dui_radar_sort_none",
             localize "STR_dui_radar_sort_name",
             localize "STR_dui_radar_sort_fireteam",
             localize "STR_dui_radar_sort_fireteam2",
-            localize "STR_dui_radar_sort_rank"
+            localize "STR_dui_radar_sort_rank",
+            localize "STR_dui_color_custom"
         ],
         0
     ]

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -36,15 +36,6 @@ if !(isClass(configfile >> "CfgPatches" >> "ace_ui")) then {
     ] call CBA_Settings_fnc_init;
 };
 
-[
-    QGVAR(syncGroups)
-    ,"CHECKBOX"
-    ,[localize "STR_dui_radar_sync_groups", localize "STR_dui_radar_sync_groups_desc"]
-    ,[CBA_SETTINGS_CAT, _curCat]
-    ,false
-    ,true
-] call CBA_Settings_fnc_init;
-
 private _curCat = localize "STR_dui_cat_compass";
 
 [
@@ -337,6 +328,48 @@ if (isClass(configfile >> "CfgPatches" >> "diwako_dui_buddy")) then {
     ,[CBA_SETTINGS_CAT, _curCat]
     ,false
     ,false
+] call CBA_Settings_fnc_init;
+
+GVAR(sortNamespace) = [] call CBA_fnc_createNamespace;
+GVAR(sortNamespace) setVariable ["main", 4];
+GVAR(sortNamespace) setVariable ["red", 0];
+GVAR(sortNamespace) setVariable ["green", 1];
+GVAR(sortNamespace) setVariable ["blue", 2];
+GVAR(sortNamespace) setVariable ["yellow", 3];
+GVAR(sortNamespace) setVariable ["PRIVATE", 6];
+GVAR(sortNamespace) setVariable ["CORPORAL", 5];
+GVAR(sortNamespace) setVariable ["SERGEANT", 4];
+GVAR(sortNamespace) setVariable ["LIEUTENANT", 3];
+GVAR(sortNamespace) setVariable ["CAPTAIN", 2];
+GVAR(sortNamespace) setVariable ["MAJOR", 1];
+GVAR(sortNamespace) setVariable ["COLONEL", 0];
+
+[
+    QGVAR(sqlFirst)
+    ,"CHECKBOX"
+    ,[localize "STR_dui_radar_sqlFirst", localize "STR_dui_radar_sqlFirst_desc"]
+    ,[CBA_SETTINGS_CAT, _curCat]
+    ,false
+    ,true
+] call CBA_Settings_fnc_init;
+
+[
+    QGVAR(sortType)
+    ,"LIST"
+    ,[localize "STR_dui_radar_sort", localize "STR_dui_radar_sort_desc"]
+    ,[CBA_SETTINGS_CAT, _curCat]
+    ,[
+        ["none", "name", "fireteam", "fireteam2", "rank"],
+        [
+            localize "STR_dui_radar_sort_none",
+            localize "STR_dui_radar_sort_name",
+            localize "STR_dui_radar_sort_fireteam",
+            localize "STR_dui_radar_sort_fireteam2",
+            localize "STR_dui_radar_sort_rank"
+        ],
+        0
+    ]
+    ,true
 ] call CBA_Settings_fnc_init;
 
 [

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -36,6 +36,15 @@ if !(isClass(configfile >> "CfgPatches" >> "ace_ui")) then {
     ] call CBA_Settings_fnc_init;
 };
 
+[
+    QGVAR(syncGroups)
+    ,"CHECKBOX"
+    ,[localize "STR_dui_radar_sync_groups", localize "STR_dui_radar_sync_groups_desc"]
+    ,[CBA_SETTINGS_CAT, _curCat]
+    ,false
+    ,true
+] call CBA_Settings_fnc_init;
+
 private _curCat = localize "STR_dui_cat_compass";
 
 [

--- a/addons/radar/functions/fnc_cacheLoop.sqf
+++ b/addons/radar/functions/fnc_cacheLoop.sqf
@@ -199,6 +199,9 @@ if (count _group <= 1) exitWith {
 if !(ctrlShown _grpCtrl) then {
     _grpCtrl ctrlShow true;
 };
+
+_group = [_group, _player] call FUNC(sortNameList);
+
 private _text = "";
 private _curList = controlNull;
 

--- a/addons/radar/functions/fnc_cacheLoop.sqf
+++ b/addons/radar/functions/fnc_cacheLoop.sqf
@@ -12,7 +12,7 @@ if !(diwako_dui_enable_compass || diwako_dui_namelist) exitWith {
 };
 
 private _player = [] call CBA_fnc_currentUnit;
-private _group = units group _player;
+private _group = (group _player) getVariable [QGVAR(syncGroup), units _player];
 if (diwako_dui_compass_hide_blip_alone_group && {(count _group) <= 1}) then {
     _group = [];
 };

--- a/addons/radar/functions/fnc_sortNameList.sqf
+++ b/addons/radar/functions/fnc_sortNameList.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+
+params ["_grp", "_player"];
+
+private _newGrp = + _grp;
+private _sqlFirst = GVAR(sqlFirst);
+private _sql = objNull;
+if (_sqlFirst) then {
+	_sql = leader _player;
+	_newGrp = _newGrp - [_sql];
+};
+
+private _nameSpace = GVAR(sortNamespace);
+
+switch (GVAR(sortType)) do {
+	case "name": {
+		_newGrp = _newGrp apply { [_x getVariable ["ACE_Name", name _x], _x] };
+		_newGrp sort true;
+		_newGrp = _newGrp apply { _x select 1 };
+	};
+	case "fireteam": {
+		_newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _x getVariable ["ACE_Name", name _x], _x] };
+		_newGrp sort true;
+		_newGrp = _newGrp apply { _x select 2 };
+	};
+	case "fireteam2": {
+		_newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
+		_newGrp sort true;
+		_newGrp = _newGrp apply { _x select 3 };
+	};
+	case "rank": {
+		_newGrp = _newGrp apply { [_nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
+		_newGrp sort true;
+		_newGrp = _newGrp apply { _x select 2 };
+	};
+	default { };
+};
+
+if (_sqlFirst) then {
+	_newGrp = [_sql] + _newGrp;
+};
+
+_newGrp

--- a/addons/radar/functions/fnc_sortNameList.sqf
+++ b/addons/radar/functions/fnc_sortNameList.sqf
@@ -6,38 +6,48 @@ private _newGrp = + _grp;
 private _sqlFirst = GVAR(sqlFirst);
 private _sql = objNull;
 if (_sqlFirst) then {
-	_sql = leader _player;
-	_newGrp = _newGrp - [_sql];
+    _sql = leader _player;
+    _newGrp = _newGrp - [_sql];
 };
 
 private _nameSpace = GVAR(sortNamespace);
 
 switch (GVAR(sortType)) do {
-	case "name": {
-		_newGrp = _newGrp apply { [_x getVariable ["ACE_Name", name _x], _x] };
-		_newGrp sort true;
-		_newGrp = _newGrp apply { _x select 1 };
-	};
-	case "fireteam": {
-		_newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _x getVariable ["ACE_Name", name _x], _x] };
-		_newGrp sort true;
-		_newGrp = _newGrp apply { _x select 2 };
-	};
-	case "fireteam2": {
-		_newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
-		_newGrp sort true;
-		_newGrp = _newGrp apply { _x select 3 };
-	};
-	case "rank": {
-		_newGrp = _newGrp apply { [_nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
-		_newGrp sort true;
-		_newGrp = _newGrp apply { _x select 2 };
-	};
-	default { };
+    case "name": {
+        _newGrp = _newGrp apply { [_x getVariable ["ACE_Name", name _x], _x] };
+        _newGrp sort true;
+        _newGrp = _newGrp apply { _x select 1 };
+    };
+    case "fireteam": {
+        _newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _x getVariable ["ACE_Name", name _x], _x] };
+        _newGrp sort true;
+        _newGrp = _newGrp apply { _x select 2 };
+    };
+    case "fireteam2": {
+        _newGrp = _newGrp apply { [_nameSpace getVariable [[assignedTeam _x] param [0, "MAIN"], 9999], _nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
+        _newGrp sort true;
+        _newGrp = _newGrp apply { _x select 3 };
+    };
+    case "rank": {
+        _newGrp = _newGrp apply { [_nameSpace getVariable [rank _x, 9999], _x getVariable ["ACE_Name", name _x], _x] };
+        _newGrp sort true;
+        _newGrp = _newGrp apply { _x select 2 };
+    };
+    case "custom": {
+        if (!isNil QGVAR(customSort) && {GVAR(customSort) isEqualType {}}) then {
+            private _customGrp = [_newGrp, _player] call GVAR(customSort);
+            if (!isNil "_customGrp" && {_customGrp isEqualType [] && { !((_customGrp select 0) isEqualType []) && {(_customGrp select 0) isKindOf "CAManBase"}}}) then {
+                _newGrp = _customGrp;
+            } else {
+                [["DUI Custom Sorting Code", 2], ["Return type is incorrect!"], ["CAManBase object expected as first entry of array!"]] call CBA_fnc_notify;
+            };
+        };
+    };
+    default { };
 };
 
 if (_sqlFirst) then {
-	_newGrp = [_sql] + _newGrp;
+    _newGrp = [_sql] + _newGrp;
 };
 
 _newGrp

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -1,40 +1,44 @@
 #include "script_component.hpp"
 
-if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exitWith {};
+// put the function into a variable so that all includes are not sent to the server
+// if the includes would be synced to a server that is not running DUI it would either crash or the function would not work
+GVAR(syncGroupVar) = {
+    if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exitWith {};
 
-GVAR(syncRunning) = true;
-// loop
-GVAR(syncPFH) = [{
-    params ["", "_pfhHandle"];
+    GVAR(syncRunning) = true;
+    // loop
+    GVAR(syncPFH) = [{
+        params ["", "_pfhHandle"];
 
-    if !(GVAR(syncRunning)) exitWith {
-        // stop pfh and remove any synced group arrays
-        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
-        GVAR(syncPFH) = nil;
+        if !(GVAR(syncRunning)) exitWith {
+            // stop pfh and remove any synced group arrays
+            [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+            GVAR(syncPFH) = nil;
+            private _grp = [];
+            {
+                _grp = _x getVariable QGVAR(syncGroup);
+                if !(isNil "_grp") then {
+                    _x setVariable [QGVAR(syncGroup), nil, true];
+                };
+            } forEach allGroups;
+        };
+
+        // get all alive player units
+        private _players = ((call CBA_fnc_players) select {alive _x}) - allCurators;
+
+        // get all groups containing players
+        private _groups = [];
+        {
+            _groups pushBackUnique (group _x);
+        } forEach _players;
+
+        // sync groups if the units array in them changed
         private _grp = [];
         {
-            _grp = _x getVariable QGVAR(syncGroup);
-            if !(isNil "_grp") then {
-                _x setVariable [QGVAR(syncGroup), nil, true];
+            _grp = units _x;
+            if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
+                _x setVariable [QGVAR(syncGroup), _grp, true];
             };
-        } forEach allGroups;
-    };
-
-    // get all alive player units
-    private _players = (switchableUnits select {isPlayer _x && {alive _x}}) - (entities "HeadlessClient_F" + allCurators);
-
-    // get all groups containing players
-    private _groups = [];
-    {
-        _groups pushBackUnique (group _x);
-    } forEach _players;
-
-    // sync groups if the units array in them changed
-    private _grp = [];
-    {
-        _grp = units _x;
-        if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
-            _x setVariable [QGVAR(syncGroup), _grp, true];
-        };
-    } forEach _groups;
-}, 2, [] ] call CBA_fnc_addPerFrameHandler;
+        } forEach _groups;
+    }, 2, [] ] call CBA_fnc_addPerFrameHandler;
+};

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -1,44 +1,40 @@
 #include "script_component.hpp"
 
-// put the function into a variable so that all includes are not sent to the server
-// if the includes would be synced to a server that is not running DUI it would either crash or the function would not work
-GVAR(syncGroupVar) = {
-    if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exitWith {};
+if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exitWith {};
 
-    GVAR(syncRunning) = true;
-    // loop
-    GVAR(syncPFH) = [{
-        params ["", "_pfhHandle"];
+GVAR(syncRunning) = true;
+// loop
+GVAR(syncPFH) = [{
+    params ["", "_pfhHandle"];
 
-        if !(GVAR(syncRunning)) exitWith {
-            // stop pfh and remove any synced group arrays
-            [_pfhHandle] call CBA_fnc_removePerFrameHandler;
-            GVAR(syncPFH) = nil;
-            private _grp = [];
-            {
-                _grp = _x getVariable QGVAR(syncGroup);
-                if !(isNil "_grp") then {
-                    _x setVariable [QGVAR(syncGroup), nil, true];
-                };
-            } forEach allGroups;
-        };
-
-        // get all alive player units
-        private _players = ((call CBA_fnc_players) select {alive _x}) - allCurators;
-
-        // get all groups containing players
-        private _groups = [];
-        {
-            _groups pushBackUnique (group _x);
-        } forEach _players;
-
-        // sync groups if the units array in them changed
+    if !(GVAR(syncRunning)) exitWith {
+        // stop pfh and remove any synced group arrays
+        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+        GVAR(syncPFH) = nil;
         private _grp = [];
         {
-            _grp = units _x;
-            if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
-                _x setVariable [QGVAR(syncGroup), _grp, true];
+            _grp = _x getVariable QGVAR(syncGroup);
+            if !(isNil "_grp") then {
+                _x setVariable [QGVAR(syncGroup), nil, true];
             };
-        } forEach _groups;
-    }, 2, [] ] call CBA_fnc_addPerFrameHandler;
-};
+        } forEach allGroups;
+    };
+
+    // get all alive player units
+    private _players = ((call CBA_fnc_players) select {alive _x}) - allCurators;
+
+    // get all groups containing players
+    private _groups = [];
+    {
+        _groups pushBackUnique (group _x);
+    } forEach _players;
+
+    // sync groups if the units array in them changed
+    private _grp = [];
+    {
+        _grp = units _x;
+        if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
+            _x setVariable [QGVAR(syncGroup), _grp, true];
+        };
+    } forEach _groups;
+}, 2, [] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+
+if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exitWith {};
+
+GVAR(syncRunning) = true;
+// loop
+GVAR(syncPFH) = [{
+    params ["", "_pfhHandle"];
+
+    if !(GVAR(syncRunning)) exitWith {
+        // stop pfh and remove any synced group arrays
+        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+        GVAR(syncPFH) = nil;
+        private _grp = [];
+        {
+            _grp = _x getVariable QGVAR(syncGroup);
+            if !(isNil "_grp") then {
+                _x setVariable [QGVAR(syncGroup), nil, true];
+            };
+        } forEach allGroups;
+    };
+
+    // get all alive player units
+    private _players = (switchableUnits select {isPlayer _x && {alive _x}}) - (entities "HeadlessClient_F" + allCurators);
+
+    // get all groups containing players
+    private _groups = [];
+    {
+        _groups pushBackUnique (group _x);
+    } forEach _players;
+
+    // sync groups if the units array in them changed
+    private _grp = [];
+    {
+        _grp = units _x;
+        if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
+            _x setVariable [QGVAR(syncGroup), _grp, true];
+        };
+    } forEach _groups;
+}, 2, [] ] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Adressing #82 

Server syncs the array that is returned by running `units _player` to everyone, in theory it should synchronize the namelist.

Usage:
If DUI running on the server, the synchronization process will start automatically, clients will attempt to tell the server to run the sync, but the server will not start a second sync PFH.

If DUI is not running on the server, clients will share the synchronization function to the server and tell it to run it. This however will not work on server running Battle eye due to the CfgRemoteExec limitations.