### PR TITLE
Remove check for map open

### DIFF
--- a/addons/main/functions/fnc_canHudBeShown.sqf
+++ b/addons/main/functions/fnc_canHudBeShown.sqf
@@ -1,13 +1,12 @@
 #include "script_component.hpp"
 params ["_player"];
 !(
-    visibleMap || 
-    {GVAR(toggled_off) || 
+    GVAR(toggled_off) || 
     {!alive _player || 
     {(_player getVariable ["ace_spectator_isSet", false]) ||
     GVAR(radioModSpectator) ||
     {dialog ||
     {diwako_dui_ace_hide_interaction && {missionNamespace getVariable ["ace_interact_menu_openedMenuType",-1] > -1} || 
     {!isnull (missionNamespace getVariable ["ace_arsenal_camera", objNull]) || 
-    {GVAR(inFeatureCamera)}}}}}}}
+    {GVAR(inFeatureCamera)}}}}}}
 )

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 5
 #define PATCHLVL 3
-#define BUILD 5
+#define BUILD 8


### PR DESCRIPTION
Checks if map is visible is already built into the controls, there is no need to check this as well. Indicators cannot rander on map, so they do not need it as well.

What is the benefit of this change? When closing the map, namelist and compass show immediately., meaning they do not pop in and may distract.