### PR TITLE
Fix bearing disappearing when no leading zeroes enabled

### DIFF
--- a/addons/radar/functions/fnc_compass.sqf
+++ b/addons/radar/functions/fnc_compass.sqf
@@ -46,9 +46,9 @@ GVAR(compass_pfHandle) = [{
 
         if (_hasCompass && {diwako_dui_enable_compass_dir == 2 || {diwako_dui_enable_compass_dir == 1 && {!(isNull objectParent _player)}}}) then {
             if (diwako_dui_dir_showMildot) then {
-                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%3' shadow='2' shadowColor='#000000'>%1 | %2</t>", [(round _dir) mod 360, [0,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, [round (_dir / 0.056250), [0,4] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
+                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%3' shadow='2' shadowColor='#000000'>%1 | %2</t>", [(round _dir) mod 360, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, [round (_dir / 0.056250), [1,4] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
             } else {
-                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%2' shadow='2' shadowColor='#000000'>%1</t>", [(round _dir) mod 360, [0,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
+                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%2' shadow='2' shadowColor='#000000'>%1</t>", [(round _dir) mod 360, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
             };
         } else {
             _dirCtrl ctrlSetText "";


### PR DESCRIPTION
When looking towards 0 degrees the bearing number would disappear when not using the leading zero option.