### PR TITLE
Feature - Add unit specific icon support

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 5
-#define PATCHLVL 4
-#define BUILD 3
+#define PATCHLVL 5
+#define BUILD 1

--- a/addons/radar/functions/fnc_getIcon.sqf
+++ b/addons/radar/functions/fnc_getIcon.sqf
@@ -43,8 +43,13 @@ if (_player == (_unit getVariable [QEGVAR(buddy,buddy), objNull])) exitWith {
 };
 
 // Leader
-if ((leader _unit) == _unit) exitWith {
+if ((leader _unit) isEqualTo _unit) exitWith {
     _namespace getVariable ["sql", DUI_SQL];
+};
+
+// Custom icon
+if !(_unit getVariable [QGVAR(customIcon), ""] isEqualTo "") exitWith {
+    _unit getVariable QGVAR(customIcon);
 };
 
 // AR


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8259498/57541275-e6e63280-734e-11e9-98d5-15d49ce2fddf.png)

Possible to add a custom icon to a specific unit
```sqf
_unit setVariable ["diwako_dui_radar_customIcon", "yes.paa", true];
```