### PR TITLE
Group icons on radar by vehicle

### DIFF
--- a/addons/buddy/XEH_postInit.sqf
+++ b/addons/buddy/XEH_postInit.sqf
@@ -1,52 +1,60 @@
 #include "script_component.hpp"
 
+if !(hasInterface) exitWith {};
+
 private _labelAdd = localize "STR_dui_buddy_action";
 private _labelRemove = localize "STR_dui_buddy_action_remove";
 private _range = 10;
 if (isNil "ace_interact_menu_fnc_createAction") then {
     [[_labelAdd, {
         [player, cursorObject] call FUNC(pairBuddies);
-    }, [], -5000, false, true, "", format ["cursorObject distance2d player <= %1 && {cursorObject in (units group player) && {(player getVariable ["QEGVAR(buddy,buddy)", objNull]) != cursorObject}}", _range]]] call CBA_fnc_addPlayerAction;
+    }, [], -5000, false, true, "", format ["cursorObject distance2d player <= %1 && {cursorObject in (units group player) && {(player getVariable ["QGVAR(buddy)", objNull]) != cursorObject}}", _range]]] call CBA_fnc_addPlayerAction;
 
     [[_labelRemove, {
         [player, cursorObject, false] call FUNC(pairBuddies);
-    }, [], -5000, false, true, "", format ["cursorObject distance2d player <= %1 && {cursorObject in (units group player) && {(player getVariable ["QEGVAR(buddy,buddy)", objNull]) == cursorObject}}", _range]]] call CBA_fnc_addPlayerAction;
+    }, [], -5000, false, true, "", format ["cursorObject distance2d player <= %1 && {cursorObject in (units group player) && {(player getVariable ["QGVAR(buddy)", objNull]) == cursorObject}}", _range]]] call CBA_fnc_addPlayerAction;
 } else {
     // root
     private _action = [QGVAR(buddy_action), _labelAdd, "", {
         [_player, _target] call FUNC(pairBuddies);
-    },{!(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {_target in (units group _player) && {(_player getVariable [QEGVAR(buddy,buddy), objNull]) != _target}}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
+    },{!(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {_target in (units group _player) && {(_player getVariable [QGVAR(buddy), objNull]) != _target}}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
     _action = [QGVAR(buddy_action_remove), _labelRemove, "", {
         [_player, _target, false] call FUNC(pairBuddies);
-    },{!(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {_target in (units group _player) && {(_player getVariable [QEGVAR(buddy,buddy), objNull]) == _target}}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
+    },{!(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {_target in (units group _player) && {(_player getVariable [QGVAR(buddy), objNull]) == _target}}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
     _action = [QGVAR(buddy_action_team_remove), _labelRemove, "", {
-        [_player, _player getVariable [QEGVAR(buddy,buddy), objNull], false] call FUNC(pairBuddies);
-    },{!ace_interaction_EnableTeamManagement && {!isNull (_player getVariable [QEGVAR(buddy,buddy), objNull])}},{},[], [0,0,0]] call ace_interact_menu_fnc_createAction;
+        [_player, _player getVariable [QGVAR(buddy), objNull], false] call FUNC(pairBuddies);
+    },{!ace_interaction_EnableTeamManagement && {!isNull (_player getVariable [QGVAR(buddy), objNull])}},{},[], [0,0,0]] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_TeamManagement"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
     // team management
     _action = [QGVAR(buddy_action_team), _labelAdd, "", {
         [_player, _target] call FUNC(pairBuddies);
-    },{(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {(_player getVariable [QEGVAR(buddy,buddy), objNull]) != _target}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
+    },{(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {(_player getVariable [QGVAR(buddy), objNull]) != _target}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 0, ["ACE_MainActions", "ACE_TeamManagement"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
     _action = [QGVAR(buddy_action_team_remove), _labelRemove, "", {
         [_player, _target, false] call FUNC(pairBuddies);
-    },{(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {(_player getVariable [QEGVAR(buddy,buddy), objNull]) == _target}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
+    },{(ace_interaction_EnableTeamManagement && [_player, _target] call ace_interaction_fnc_canJoinTeam) && {(_player getVariable [QGVAR(buddy), objNull]) == _target}},{},[], [0,0,0], _range] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 0, ["ACE_MainActions", "ACE_TeamManagement"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
     _action = [QGVAR(buddy_action_team_remove), _labelRemove, "", {
-        [_player, _player getVariable [QEGVAR(buddy,buddy), objNull], false] call FUNC(pairBuddies);
-    },{ace_interaction_EnableTeamManagement && {!isNull (_player getVariable [QEGVAR(buddy,buddy), objNull])}},{},[], [0,0,0]] call ace_interact_menu_fnc_createAction;
+        [_player, _player getVariable [QGVAR(buddy), objNull], false] call FUNC(pairBuddies);
+    },{ace_interaction_EnableTeamManagement && {!isNull (_player getVariable [QGVAR(buddy), objNull])}},{},[], [0,0,0]] call ace_interact_menu_fnc_createAction;
 
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_TeamManagement"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 };
+
+player addEventHandler ["Respawn", {
+    params ["_new", "_old"];
+    [_old, _old getVariable [QGVAR(buddy), objNull], false] call FUNC(pairBuddies);
+    _new setVariable [QGVAR(buddy), nil, true];
+}];

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 5
 #define PATCHLVL 5
-#define BUILD 1
+#define BUILD 3

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1430,5 +1430,13 @@
             <Portuguese>Patente, Nomes</Portuguese>
             <Japanese>階級、名前</Japanese>
         </Key>
+        <Key ID="STR_dui_radar_group_by_vehicle">
+            <English>Group Icons by Vehicle</English>
+            <German>Icons nach Fahrzeug gruppieren</German>
+        </Key>
+        <Key ID="STR_dui_radar_group_by_vehicle_desc">
+            <English>Shows only one icon of your squad if multiple members are in the same vehicle, usually the driver.</English>
+            <German>Zeigt nur ein Icon deines Squads an, wenn mehrere Gruppenmitglieder im selben Fahrzeug sitzen, normalerweise den Fahrer.</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -228,6 +228,15 @@ private _curCat = localize "STR_dui_cat_compass";
 ] call CBA_Settings_fnc_init;
 
 [
+    QGVAR(group_by_vehicle)
+    ,"CHECKBOX"
+    ,[localize "STR_dui_radar_group_by_vehicle", localize "STR_dui_radar_group_by_vehicle_desc"]
+    ,[CBA_SETTINGS_CAT, _curCat]
+    ,false
+    ,false
+] call CBA_Settings_fnc_init;
+
+[
     QGVAR(trackingColor)
     ,"COLOR"
     ,[localize "STR_dui_trackingColor_time", localize "STR_dui_trackingColor_desc"]

--- a/addons/radar/functions/fnc_cacheLoop.sqf
+++ b/addons/radar/functions/fnc_cacheLoop.sqf
@@ -16,7 +16,23 @@ private _group = (group _player) getVariable [QGVAR(syncGroup), units _player];
 if (diwako_dui_compass_hide_blip_alone_group && {(count _group) <= 1}) then {
     _group = [];
 };
-GVAR(group) = + _group;
+
+if (GVAR(group_by_vehicle)) then {
+    private _newGrp = _group apply { [objectParent _x, [1,0] select ((driver vehicle _x) isEqualTo _x), _x] };
+    _newGrp sort true;
+    _newGrp = _newGrp apply { _x select 2 };
+
+    private _dummyList = [];
+    private _filteredGrp = [];
+    {
+        if (_dummyList pushBackUnique (vehicle _x) != -1) then {
+            _filteredGrp pushBack _x;
+        };
+    } forEach _newGrp;
+    GVAR(group) = _filteredGrp;
+} else {
+    GVAR(group) = + _group;
+};
 
 private _uiScale = diwako_dui_hudScaling;
 private _uiPixels = GVAR(uiPixels);


### PR DESCRIPTION
Adds a setting to show only one icon on the radar by vehicle. It is usually the driver position if the group member is sitting behind the wheel.

Example with a full Hemtt
Setting enabled
![image](https://user-images.githubusercontent.com/8259498/61576252-f1077880-aad7-11e9-8a02-d69acda9c725.png)

Setting disabled (default and current)
![image](https://user-images.githubusercontent.com/8259498/61576258-02e91b80-aad8-11e9-858b-8cc172c29ef6.png)

Special tracked units are exempt from this setting.
