### PR TITLE
Indicator - Use the same custom icon as the wiki

### DIFF
--- a/addons/indicators/functions/fnc_cacheLoop.sqf
+++ b/addons/indicators/functions/fnc_cacheLoop.sqf
@@ -15,7 +15,7 @@ if (GVAR(show)) then {
 
     private _innerIcon = "";
     {
-        _innerIcon = _x getVariable [QEGVAR(radar,customIcon), ""];
+        _innerIcon = _x getVariable [QGVAR(customIcon), ""];
         if (_innerIcon isEqualTo "") then {
             if (GVAR(icon_buddy) && {_x isEqualTo (_player getVariable [QEGVAR(buddy,buddy), objNull])}) then {
                 _innerIcon = _indicatorNamespace getVariable ["buddy", ""];

--- a/addons/indicators/functions/fnc_cacheLoop.sqf
+++ b/addons/indicators/functions/fnc_cacheLoop.sqf
@@ -15,7 +15,7 @@ if (GVAR(show)) then {
 
     private _innerIcon = "";
     {
-        _innerIcon = _x getVariable [QGVAR(icon), ""];
+        _innerIcon = _x getVariable [QEGVAR(radar,customIcon), ""];
         if (_innerIcon isEqualTo "") then {
             if (GVAR(icon_buddy) && {_x isEqualTo (_player getVariable [QEGVAR(buddy,buddy), objNull])}) then {
                 _innerIcon = _indicatorNamespace getVariable ["buddy", ""];


### PR DESCRIPTION
Changes the name of the indicator's custom icon to be consistent with the radar