### PR TITLE
dont run GUI updates while game is paused or minimized

### DIFF
--- a/addons/radar/XEH_PREP.hpp
+++ b/addons/radar/XEH_PREP.hpp
@@ -1,10 +1,12 @@
 PREP(cacheLoop);
 PREP(compass);
+PREP(compassPFH);
 PREP(displayUnitOnCompass);
 PREP(getIcon);
 PREP(rangeButton);
 PREP(setCustomCode);
 PREP(syncGroups);
+PREP(syncGroupsPFH);
 PREP(sortNameList);
 PREP(getCompass);
 PREP(incomingFinger);

--- a/addons/radar/functions/fnc_compass.sqf
+++ b/addons/radar/functions/fnc_compass.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+
 if (is3DEN || !hasInterface) exitWith {};
 params [["_display", displayNull]];
 if !(diwako_dui_enable_compass) exitWith {};
@@ -12,96 +13,4 @@ if (isNull _display) exitWith {systemChat "No Display"};
 private _ctrlGrp = _display displayCtrl IDC_COMPASS_CTRLGRP;
 private _compass = _display displayCtrl IDC_COMPASS;
 private _dirCtrl = _display displayCtrl IDC_DIRECTION;
-GVAR(compass_pfHandle) = [{
-    params ["_args", "_pfhHandle"];
-    _args params ["_display", "_compassCtrl", "_dirCtrl", "_ctrlGrp"];
-
-    if (!isGameFocused || isGamePaused) exitWith {};
-
-    if !(diwako_dui_enable_compass) exitWith {
-        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
-        "diwako_dui_compass" cutText ["","PLAIN"];
-        GVAR(compass_pfHandle) = -1;
-    };
-
-    private _player = [] call CBA_fnc_currentUnit;
-    private _grp = GVAR(group);
-    private _pointers = GVAR(pointers);
-
-    if (diwako_dui_compass_hide_alone_group && {count (units group _player) <= 1}) exitWith {
-        _compassCtrl ctrlShow false;
-        _dirCtrl ctrlShow false;
-        _ctrlGrp ctrlShow false;
-    };
-
-    if ([_player] call EFUNC(main,canHudBeShown)) then {
-        if !(ctrlShown _ctrlGrp) then {
-            _ctrlGrp ctrlShow true;
-            _compassCtrl ctrlShow true;
-            _dirCtrl ctrlShow true;
-        };
-        private _camDirVec = positionCameratoWorld [0,0,0] vectorFromTo (positionCameraToWorld [0,0,1]);
-        private _dir = _camDirVec call CBA_fnc_vectDir;
-        // private _dir = (getCameraViewDirection _player) call CBA_fnc_vectDir;
-        private _hasCompass = !(([_player] call FUNC(getCompass)) isEqualTo "");
-
-        _compassCtrl ctrlSetAngle [[0,-_dir] select _hasCompass, 0.5, 0.5, true];
-
-        if (_hasCompass && {diwako_dui_enable_compass_dir == 2 || {diwako_dui_enable_compass_dir == 1 && {!(isNull objectParent _player)}}}) then {
-            private _dirCalc = (round _dir) mod 360;
-            private _maxDegrees = GVAR(maxDegrees);
-            if (_maxDegrees != 360) then {
-                _dirCalc = (round (linearConversion [0, 360, _dir, 0, _maxDegrees, true])) mod _maxDegrees;
-            };
-            if (!(_maxDegrees isEqualTo 6400) && {diwako_dui_dir_showMildot}) then {
-                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%3' shadow='2' shadowColor='#000000'>%1 | %2</t>", [_dirCalc, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, [round (_dir / 0.056250), [1,4] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
-            } else {
-                _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%2' shadow='2' shadowColor='#000000'>%1</t>", [_dirCalc, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
-            };
-        } else {
-            _dirCtrl ctrlSetText "";
-        };
-
-        private _ctrls = _ctrlGrp getVariable ["diwako_dui_ctrlArr",[]];
-        private _playerDir = getDir _player;
-
-        private _usedCtrls = [_grp, _display, _dir, _playerDir, _player, _ctrlGrp] call FUNC(displayUnitOnCompass);
-
-        {
-            ctrlDelete _x;
-        } forEach (_ctrls - _usedCtrls);
-
-        if (diwako_dui_compass_hide_blip_alone_group && { _grp isEqualTo (missionNamespace getVariable ["diwako_dui_special_track", []]) && {(count _usedCtrls) > 0}}) then {
-            _usedCtrls pushBack (([[_player], _display, _dir, _playerDir, _player, _ctrlGrp] call FUNC(displayUnitOnCompass)) select 0);
-        };
-        _ctrlGrp setVariable ["diwako_dui_ctrlArr", _usedCtrls];
-
-        if !(_pointers isEqualTo []) then {
-            for "_i" from (count _pointers) -1 to 0 step -1 do {
-                (_pointers#_i) params [["_pointer", controlNull], "_pointerPos"];
-                if (isNull _pointer) then {
-                    _pointers deleteAt _i;
-                } else {
-                    _pointer ctrlSetAngle [(((_player getRelDir (_pointerPos)) - (_dir - _playerDir) ) mod 360), 0.5, 0.5, false];
-                    _pointer ctrlCommit 0;
-                };
-            };
-        };
-
-        if !(isNil "diwako_dui_custom_code") then {
-            /*
-                Keep in mind this runs EVERY FRAME!
-                1. Display of the RscTile
-                2. Control of the compass
-                3. Control of the bearing indicator
-                4. Control group of the units displayed on the compass
-                5. All currently shown unit icons on the compass
-            */
-            [_display, _compassCtrl, _dirCtrl, _ctrlGrp, _usedCtrls] call diwako_dui_custom_code;
-        };
-    } else {
-        _compassCtrl ctrlShow false;
-        _dirCtrl ctrlShow false;
-        _ctrlGrp ctrlShow false;
-    };
-}, diwako_dui_compassRefreshrate, [_display, _compass, _dirCtrl, _ctrlGrp] ] call CBA_fnc_addPerFrameHandler;
+GVAR(compass_pfHandle) = [GVAR(fnc_compassPFH), diwako_dui_compassRefreshrate, [_display, _compass, _dirCtrl, _ctrlGrp] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/radar/functions/fnc_compass.sqf
+++ b/addons/radar/functions/fnc_compass.sqf
@@ -16,6 +16,8 @@ GVAR(compass_pfHandle) = [{
     params ["_args", "_pfhHandle"];
     _args params ["_display", "_compassCtrl", "_dirCtrl", "_ctrlGrp"];
 
+    if (!isGameFocused || isGamePaused) exitWith {};
+
     if !(diwako_dui_enable_compass) exitWith {
         [_pfhHandle] call CBA_fnc_removePerFrameHandler;
         "diwako_dui_compass" cutText ["","PLAIN"];

--- a/addons/radar/functions/fnc_compass.sqf
+++ b/addons/radar/functions/fnc_compass.sqf
@@ -13,4 +13,4 @@ if (isNull _display) exitWith {systemChat "No Display"};
 private _ctrlGrp = _display displayCtrl IDC_COMPASS_CTRLGRP;
 private _compass = _display displayCtrl IDC_COMPASS;
 private _dirCtrl = _display displayCtrl IDC_DIRECTION;
-GVAR(compass_pfHandle) = [GVAR(fnc_compassPFH), diwako_dui_compassRefreshrate, [_display, _compass, _dirCtrl, _ctrlGrp] ] call CBA_fnc_addPerFrameHandler;
+GVAR(compass_pfHandle) = [FUNC(compassPFH), diwako_dui_compassRefreshrate, [_display, _compass, _dirCtrl, _ctrlGrp] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/radar/functions/fnc_compassPFH.sqf
+++ b/addons/radar/functions/fnc_compassPFH.sqf
@@ -1,0 +1,94 @@
+#include "script_component.hpp"
+
+
+params ["_args", "_pfhHandle"];
+_args params ["_display", "_compassCtrl", "_dirCtrl", "_ctrlGrp"];
+
+if (!isGameFocused || isGamePaused) exitWith {};
+
+if !(diwako_dui_enable_compass) exitWith {
+    [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+    "diwako_dui_compass" cutText ["","PLAIN"];
+    GVAR(compass_pfHandle) = -1;
+};
+
+private _player = [] call CBA_fnc_currentUnit;
+private _grp = GVAR(group);
+private _pointers = GVAR(pointers);
+
+if (diwako_dui_compass_hide_alone_group && {count (units group _player) <= 1}) exitWith {
+    _compassCtrl ctrlShow false;
+    _dirCtrl ctrlShow false;
+    _ctrlGrp ctrlShow false;
+};
+
+if ([_player] call EFUNC(main,canHudBeShown)) then {
+    if !(ctrlShown _ctrlGrp) then {
+        _ctrlGrp ctrlShow true;
+        _compassCtrl ctrlShow true;
+        _dirCtrl ctrlShow true;
+    };
+    private _camDirVec = positionCameratoWorld [0,0,0] vectorFromTo (positionCameraToWorld [0,0,1]);
+    private _dir = _camDirVec call CBA_fnc_vectDir;
+    // private _dir = (getCameraViewDirection _player) call CBA_fnc_vectDir;
+    private _hasCompass = !(([_player] call FUNC(getCompass)) isEqualTo "");
+
+    _compassCtrl ctrlSetAngle [[0,-_dir] select _hasCompass, 0.5, 0.5, true];
+
+    if (_hasCompass && {diwako_dui_enable_compass_dir == 2 || {diwako_dui_enable_compass_dir == 1 && {!(isNull objectParent _player)}}}) then {
+        private _dirCalc = (round _dir) mod 360;
+        private _maxDegrees = GVAR(maxDegrees);
+        if (_maxDegrees != 360) then {
+            _dirCalc = (round (linearConversion [0, 360, _dir, 0, _maxDegrees, true])) mod _maxDegrees;
+        };
+        if (!(_maxDegrees isEqualTo 6400) && {diwako_dui_dir_showMildot}) then {
+            _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%3' shadow='2' shadowColor='#000000'>%1 | %2</t>", [_dirCalc, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, [round (_dir / 0.056250), [1,4] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
+        } else {
+            _dirCtrl ctrlSetStructuredText parseText format ["<t align='center' size='%2' shadow='2' shadowColor='#000000'>%1</t>", [_dirCalc, [1,3] select GVAR(leadingZeroes)] call CBA_fnc_formatNumber, GVAR(bearing_size_calc)];
+        };
+    } else {
+        _dirCtrl ctrlSetText "";
+    };
+
+    private _ctrls = _ctrlGrp getVariable ["diwako_dui_ctrlArr",[]];
+    private _playerDir = getDir _player;
+
+    private _usedCtrls = [_grp, _display, _dir, _playerDir, _player, _ctrlGrp] call FUNC(displayUnitOnCompass);
+
+    {
+        ctrlDelete _x;
+    } forEach (_ctrls - _usedCtrls);
+
+    if (diwako_dui_compass_hide_blip_alone_group && { _grp isEqualTo (missionNamespace getVariable ["diwako_dui_special_track", []]) && {(count _usedCtrls) > 0}}) then {
+        _usedCtrls pushBack (([[_player], _display, _dir, _playerDir, _player, _ctrlGrp] call FUNC(displayUnitOnCompass)) select 0);
+    };
+    _ctrlGrp setVariable ["diwako_dui_ctrlArr", _usedCtrls];
+
+    if !(_pointers isEqualTo []) then {
+        for "_i" from (count _pointers) -1 to 0 step -1 do {
+            (_pointers#_i) params [["_pointer", controlNull], "_pointerPos"];
+            if (isNull _pointer) then {
+                _pointers deleteAt _i;
+            } else {
+                _pointer ctrlSetAngle [(((_player getRelDir (_pointerPos)) - (_dir - _playerDir) ) mod 360), 0.5, 0.5, false];
+                _pointer ctrlCommit 0;
+            };
+        };
+    };
+
+    if !(isNil "diwako_dui_custom_code") then {
+        /*
+            Keep in mind this runs EVERY FRAME!
+            1. Display of the RscTile
+            2. Control of the compass
+            3. Control of the bearing indicator
+            4. Control group of the units displayed on the compass
+            5. All currently shown unit icons on the compass
+        */
+        [_display, _compassCtrl, _dirCtrl, _ctrlGrp, _usedCtrls] call diwako_dui_custom_code;
+    };
+} else {
+    _compassCtrl ctrlShow false;
+    _dirCtrl ctrlShow false;
+    _ctrlGrp ctrlShow false;
+};

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -7,6 +7,8 @@ GVAR(syncRunning) = true;
 GVAR(syncPFH) = [{
     params ["", "_pfhHandle"];
 
+    if (!isGameFocused || isGamePaused) exitWith {};
+
     if !(GVAR(syncRunning)) exitWith {
         // stop pfh and remove any synced group arrays
         [_pfhHandle] call CBA_fnc_removePerFrameHandler;

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -4,39 +4,4 @@ if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exi
 
 GVAR(syncRunning) = true;
 // loop
-GVAR(syncPFH) = [{
-    params ["", "_pfhHandle"];
-
-    if (!isGameFocused || isGamePaused) exitWith {};
-
-    if !(GVAR(syncRunning)) exitWith {
-        // stop pfh and remove any synced group arrays
-        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
-        GVAR(syncPFH) = nil;
-        private _grp = [];
-        {
-            _grp = _x getVariable QGVAR(syncGroup);
-            if !(isNil "_grp") then {
-                _x setVariable [QGVAR(syncGroup), nil, true];
-            };
-        } forEach allGroups;
-    };
-
-    // get all alive player units
-    private _players = ((call CBA_fnc_players) select {alive _x}) - allCurators;
-
-    // get all groups containing players
-    private _groups = [];
-    {
-        _groups pushBackUnique (group _x);
-    } forEach _players;
-
-    // sync groups if the units array in them changed
-    private _grp = [];
-    {
-        _grp = units _x;
-        if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
-            _x setVariable [QGVAR(syncGroup), _grp, true];
-        };
-    } forEach _groups;
-}, 2, [] ] call CBA_fnc_addPerFrameHandler;
+GVAR(syncPFH) = [GVAR(fnc_syncGroupsPFH), 2, [] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/radar/functions/fnc_syncGroups.sqf
+++ b/addons/radar/functions/fnc_syncGroups.sqf
@@ -4,4 +4,4 @@ if (!isServer || {missionNamespace getVariable [QGVAR(syncRunning), false]}) exi
 
 GVAR(syncRunning) = true;
 // loop
-GVAR(syncPFH) = [GVAR(fnc_syncGroupsPFH), 2, [] ] call CBA_fnc_addPerFrameHandler;
+GVAR(syncPFH) = [FUNC(syncGroupsPFH), 2, [] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/radar/functions/fnc_syncGroupsPFH.sqf
+++ b/addons/radar/functions/fnc_syncGroupsPFH.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+
+params ["", "_pfhHandle"];
+
+if (!isGameFocused || isGamePaused) exitWith {};
+
+if !(GVAR(syncRunning)) exitWith {
+    // stop pfh and remove any synced group arrays
+    [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+    GVAR(syncPFH) = nil;
+    private _grp = [];
+    {
+        _grp = _x getVariable QGVAR(syncGroup);
+        if !(isNil "_grp") then {
+            _x setVariable [QGVAR(syncGroup), nil, true];
+        };
+    } forEach allGroups;
+};
+
+// get all alive player units
+private _players = ((call CBA_fnc_players) select {alive _x}) - allCurators;
+
+// get all groups containing players
+private _groups = [];
+{
+    _groups pushBackUnique (group _x);
+} forEach _players;
+
+// sync groups if the units array in them changed
+private _grp = [];
+{
+    _grp = units _x;
+    if !(_grp isEqualTo (_x getVariable [QGVAR(syncGroup), []])) then {
+        _x setVariable [QGVAR(syncGroup), _grp, true];
+    };
+} forEach _groups;


### PR DESCRIPTION
I put the PFHs into their own compiled functions  for debugging purposes and becaise it felt good.

----

does this optimization even matter? not really I guess.
(possible exception: if you've got the game minimized for a longer period of time, I *think* it tries to re-draw all the things for every frame once you restore the window… not sure?)

still warm fuzzy feeling when getting shorter execution times:

without optimization: executions take ~0.5ms for the compass PFH

![no](https://user-images.githubusercontent.com/52833/81481043-a05f3880-922d-11ea-96e9-066c50138034.png)

with optimization: executions while minimized takes ~0.01ms (looks similar for paused game)

![yes](https://user-images.githubusercontent.com/52833/81481045-a0f7cf00-922d-11ea-8bd5-aa439a46185a.png)

didnt test the syncGroups thing because I couldnt be botheres to do a test on a dedi 😛 

