### PR TITLE
Ability to choose when to display medic icon

### DIFF
--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1541,17 +1541,11 @@
             <English>Speaking icon will only appear when receiving or talking on radio not when talking locally to others</English>
             <German>Das Sprachicon wird nur angezeigt wenn man über ein Radio kommuniziert und nicht wenn lokal gesprochen wird</German>
         </Key>
-        <Key ID="STR_dui_radar_ace_medic_toggle">
+        <Key ID="STR_diwako_dui_radar_ace_medic">
             <English>ACE Medic Toggle</English>
         </Key>
-        <Key ID="STR_dui_radar_ace_medic_toggle_desc">
-            <English>Choose whether to show medics by classname or ACE variable</English>
-        </Key>
-        <Key ID="STR_dui_radar_known_medics">
-            <English>Medic Classnames</English>
-        </Key>
-        <Key ID="STR_dui_radar_known_medics_desc">
-            <English>List of classnames to consider as medics</English>
+        <Key ID="STR_diwako_dui_radar_ace_medic_desc">
+            <English>Choose whether to show medics by vanilla trait or ACE variable</English>
         </Key>
     </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1541,5 +1541,17 @@
             <English>Speaking icon will only appear when receiving or talking on radio not when talking locally to others</English>
             <German>Das Sprachicon wird nur angezeigt wenn man über ein Radio kommuniziert und nicht wenn lokal gesprochen wird</German>
         </Key>
+        <Key ID="STR_dui_radar_ace_medic_toggle">
+            <English>ACE Medic Toggle</English>
+        </Key>
+        <Key ID="STR_dui_radar_ace_medic_toggle_desc">
+            <English>Choose whether to show medics by classname or ACE variable</English>
+        </Key>
+        <Key ID="STR_dui_radar_known_medics">
+            <English>Medic Classnames</English>
+        </Key>
+        <Key ID="STR_dui_radar_known_medics_desc">
+            <English>List of classnames to consider as medics</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -87,7 +87,7 @@ if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
         ,[localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)]
         ,[CBA_SETTINGS_CAT, _curCat]
         ,true
-        true
+        ,true
     ] call CBA_fnc_addSetting;
 
 } else {

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -80,6 +80,29 @@ if (_acre || _tfar) then {
     GVAR(showSpeaking_replaceIcon) = false;
 };
 
+[
+  "diwako_dui_toggleAceMedic",
+  "CHECKBOX",
+  [localize "STR_dui_ace_medic_toggle", localize "STR_dui_ace_medic_toggle_desc"],
+  [CBA_SETTINGS_CAT, _curCat],
+  true,
+  true
+] call CBA_fnc_addSetting;
+
+[
+  "diwako_dui_known_medics",
+  "LIST",
+  [localize "STR_dui_known_medics", localize "STR_dui_known_medics_desc"],
+  [CBA_SETTINGS_CAT, _curCat],
+  [
+    "B_medic_F"
+  ],
+  false,
+  {
+    [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
+  }
+] call CBA_fnc_addSetting;
+
 private _curCat = localize "STR_dui_cat_compass";
 
 [

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -87,10 +87,7 @@ if (isClass (configfile >> "CfgPatches" >> "ace_medical_engine")) then {
     [localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)],
     [CBA_SETTINGS_CAT, _curCat],
     true,
-    true,
-    {
-      [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
-    }
+    true
   ] call CBA_fnc_addSetting;
 
 } else {

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -80,28 +80,22 @@ if (_acre || _tfar) then {
     GVAR(showSpeaking_replaceIcon) = false;
 };
 
-[
-  "diwako_dui_toggleAceMedic",
-  "CHECKBOX",
-  [localize "STR_dui_radar_ace_medic_toggle", localize "STR_dui_radar_ace_medic_toggle_desc"],
-  [CBA_SETTINGS_CAT, _curCat],
-  true,
-  true
-] call CBA_fnc_addSetting;
-
-[
-  "diwako_dui_known_medics",
-  "LIST",
-  [localize "STR_dui_radar_known_medics", localize "STR_dui_radar_known_medics_desc"],
-  [CBA_SETTINGS_CAT, _curCat],
+if (isClass (configfile >> "CfgPatches" >> "ace_medical_engine")) then {
   [
-    "B_medic_F"
-  ],
-  false,
-  {
-    [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
-  }
-] call CBA_fnc_addSetting;
+    QGVAR(ace_medic),
+    "CHECKBOX",
+    [localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)],
+    [CBA_SETTINGS_CAT, _curCat],
+    true,
+    true,
+    {
+      [QGVAR(refreshUI),[]] call CBA_fnc_localEvent;
+    }
+  ] call CBA_fnc_addSetting;
+
+} else {
+  GVAR(ace_medic) = false;
+};
 
 private _curCat = localize "STR_dui_cat_compass";
 

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -83,7 +83,7 @@ if (_acre || _tfar) then {
 [
   "diwako_dui_toggleAceMedic",
   "CHECKBOX",
-  [localize "STR_dui_ace_medic_toggle", localize "STR_dui_ace_medic_toggle_desc"],
+  [localize "STR_dui_radar_ace_medic_toggle", localize "STR_dui_radar_ace_medic_toggle_desc"],
   [CBA_SETTINGS_CAT, _curCat],
   true,
   true
@@ -92,7 +92,7 @@ if (_acre || _tfar) then {
 [
   "diwako_dui_known_medics",
   "LIST",
-  [localize "STR_dui_known_medics", localize "STR_dui_known_medics_desc"],
+  [localize "STR_dui_radar_known_medics", localize "STR_dui_radar_known_medics_desc"],
   [CBA_SETTINGS_CAT, _curCat],
   [
     "B_medic_F"

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -84,7 +84,7 @@ if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
     [
         QGVAR(ace_medic)
         ,"CHECKBOX"
-        ,[localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)]
+        ,[LSTRING(ace_medic), LSTRING(ace_medic_desc)]
         ,[CBA_SETTINGS_CAT, _curCat]
         ,true
         ,true

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -80,7 +80,7 @@ if (_acre || _tfar) then {
     GVAR(showSpeaking_replaceIcon) = false;
 };
 
-if (isClass (configfile >> "CfgPatches" >> "ace_medical_engine")) then {
+if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
     [
         QGVAR(ace_medic)
         ,"CHECKBOX"

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -81,17 +81,17 @@ if (_acre || _tfar) then {
 };
 
 if (isClass (configfile >> "CfgPatches" >> "ace_medical_engine")) then {
-  [
-    QGVAR(ace_medic),
-    "CHECKBOX",
-    [localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)],
-    [CBA_SETTINGS_CAT, _curCat],
-    true,
-    true
-  ] call CBA_fnc_addSetting;
+    [
+        QGVAR(ace_medic)
+        ,"CHECKBOX"
+        ,[localize LSTRING(ace_medic), localize LSTRING(ace_medic_desc)]
+        ,[CBA_SETTINGS_CAT, _curCat]
+        ,true
+        true
+    ] call CBA_fnc_addSetting;
 
 } else {
-  GVAR(ace_medic) = false;
+    GVAR(ace_medic) = false;
 };
 
 private _curCat = localize "STR_dui_cat_compass";

--- a/addons/radar/functions/fnc_getIcon.sqf
+++ b/addons/radar/functions/fnc_getIcon.sqf
@@ -63,12 +63,15 @@ if (getText(configFile >> "CfgWeapons" >> (secondaryWeapon (_unit)) >> "UIPictur
 };
 
 // Medic
-if (diwako_dui_toggleAceMedic) then {
-    if (_unit getVariable ["ace_medical_medicClass", [0, 1] select (_unit getUnitTrait "medic")] > 0) exitWith {
+if (GVAR(ace_medic)) then {
+
+    if (_unit getVariable ["ace_medical_medicClass", 0] > 0) exitWith {
         _namespace getVariable ["medic", DUI_MEDIC];
     };
+
 } else {
-    if (typeOf _unit in diwako_dui_known_medics) exitWith {
+
+    if (_unit getUnitTrait "medic") exitWith {
         _namespace getVariable ["medic", DUI_MEDIC];
     };
 };

--- a/addons/radar/functions/fnc_getIcon.sqf
+++ b/addons/radar/functions/fnc_getIcon.sqf
@@ -63,8 +63,14 @@ if (getText(configFile >> "CfgWeapons" >> (secondaryWeapon (_unit)) >> "UIPictur
 };
 
 // Medic
-if (_unit getVariable ["ace_medical_medicClass", [0, 1] select (_unit getUnitTrait "medic")] > 0) exitWith {
-    _namespace getVariable ["medic", DUI_MEDIC];
+if (diwako_dui_toggleAceMedic) then {
+    if (_unit getVariable ["ace_medical_medicClass", [0, 1] select (_unit getUnitTrait "medic")] > 0) exitWith {
+        _namespace getVariable ["medic", DUI_MEDIC];
+    };
+} else {
+    if (typeOf _unit in diwako_dui_known_medics) exitWith {
+        _namespace getVariable ["medic", DUI_MEDIC];
+    };
 };
 
 // Engineer

--- a/addons/radar/functions/fnc_getIcon.sqf
+++ b/addons/radar/functions/fnc_getIcon.sqf
@@ -63,17 +63,11 @@ if (getText(configFile >> "CfgWeapons" >> (secondaryWeapon (_unit)) >> "UIPictur
 };
 
 // Medic
-if (GVAR(ace_medic)) then {
-
-    if (_unit getVariable ["ace_medical_medicClass", 0] > 0) exitWith {
-        _namespace getVariable ["medic", DUI_MEDIC];
-    };
-
-} else {
-
-    if (_unit getUnitTrait "medic") exitWith {
-        _namespace getVariable ["medic", DUI_MEDIC];
-    };
+if (GVAR(ace_medic) && {_unit getVariable ["ace_medical_medicClass", [0, 1] select (_unit getUnitTrait "medic")] > 0}) exitWith {
+    _namespace getVariable ["medic", DUI_MEDIC];
+};
+if (!GVAR(ace_medic) && {_unit getUnitTrait "medic"}) exitWith {
+    _namespace getVariable ["medic", DUI_MEDIC];
 };
 
 // Engineer

--- a/authors.txt
+++ b/authors.txt
@@ -24,6 +24,7 @@ dystopian (medic trait detection)
 veteran29 (IFA compass suport)
 Fusselwurm (Performance improvements while game is paused or minmized)
 10Dozen (Crew long range radar/indicators)
+Brazzer (Medic icon switch between ACE/Vanilla)
 
 Special thanks:
 alganthe (General Arma modding support)


### PR DESCRIPTION
Hello,
this pull request will add the ability to toggle the use of a custom array of classnames over the default ACE variable check for medical units.

The idea is that by default your mod behaves as always, but if the added checkbox is unchecked, then the radar will display the medic icon only if a unit's classname is contained in the custom array of the "secondary" setting added. At the moment the array only contains the vanilla Medic, if you want I can provide also other classnames (such as paramedic, or the one from RHS for example).

I also added a partial stringtable, I didn't want to rely on google translate so I only added English, but I can also provide French and Italian.

Thank you!