### PR TITLE
Use VIEW lod in Nametags

### DIFF
--- a/addons/nametags/functions/fnc_onDraw.sqf
+++ b/addons/nametags/functions/fnc_onDraw.sqf
@@ -19,7 +19,7 @@ if (GVAR(useLIS)) then {
         objNull,
         true,
         -1,
-        "FIRE"
+        "VIEW"
     ];
     {
         _x params ["", "", "_obj"];


### PR DESCRIPTION
### When merged this pull request will:

1. *Uses VIEW LOD instead of FIRE LOD*

using Fire LOD had some issues with Vehicles moving at Height Velocity with Detection.
