### PR TITLE
Nametags - Fix not showing UAVs with names

### DIFF
--- a/addons/nametags/functions/fnc_onDraw.sqf
+++ b/addons/nametags/functions/fnc_onDraw.sqf
@@ -33,7 +33,7 @@ if (GVAR(useLIS)) then {
     } forEach _lis;
 };
 
-if (isNull _target || !(player call EFUNC(main,canHudBeShown))) then {
+if (isNull _target || {!(player call EFUNC(main,canHudBeShown)) || {unitIsUAV _target}}) then {
     GVAR(targetedFade) = 1;
 } else {
 

--- a/addons/nametags/functions/fnc_onDraw.sqf
+++ b/addons/nametags/functions/fnc_onDraw.sqf
@@ -49,7 +49,7 @@ if (isNull _target || {!(player call EFUNC(main,canHudBeShown)) || {unitIsUAV _t
     } else {
         _targetSide isEqualTo _playerSide;
     };
-    if (_target isKindOf "AllVehicles" && {_areFriendly} && {!unitIsUAV _target}) then {
+    if (_target isKindOf "AllVehicles" && {_areFriendly}) then {
         GVAR(targetedFade) = [_target, _player] call FUNC(calculateFadeValue);
         if (GVAR(targetedFade) < 1) then {
             private _color = EGVAR(main,colors_custom) getVariable ["otherName", "#33FF00"]; // Other Group Default Color


### PR DESCRIPTION
The unitisUAV check needs to be moved earlier as  the use of effectiveCommander results in the target no longer being regarded as a UAV. This means it will still be shown.