### PR TITLE
Radar - Add an option to show bearing only if the player has a GPS

### DIFF
--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -587,6 +587,9 @@
             <English>Driver only</English>
             <German>Nur Fahrer</German>
         </Key>
+        <Key ID="STR_dui_show_dir_opt5">
+            <English>If the player has GPS</English>
+        </Key>
         <Key ID="STR_dui_ui_scale">
             <English>UI Scaling</English>
             <Chinesesimp>UI大小</Chinesesimp>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -588,7 +588,7 @@
             <German>Nur Fahrer</German>
         </Key>
         <Key ID="STR_dui_show_dir_opt5">
-            <English>If the player has GPS</English>
+            <English>Only with GPS</English>
         </Key>
         <Key ID="STR_dui_ui_scale">
             <English>UI Scaling</English>

--- a/addons/radar/XEH_PREP.hpp
+++ b/addons/radar/XEH_PREP.hpp
@@ -9,4 +9,5 @@ PREP(syncGroups);
 PREP(syncGroupsPFH);
 PREP(sortNameList);
 PREP(getCompass);
+PREP(getGPS);
 PREP(incomingFinger);

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -19,11 +19,8 @@ GVAR(setNamelist) = true;
 // compass whitelist, these need to be lowercase!!
 GVAR(compassWhitelist) = "getText (_x >> 'simulation') == 'ItemCompass'" configClasses (configFile >> "CfgWeapons") apply {configName _x};
 
-// GPS whitelist
-private _uavTerminals = "inheritsFrom _x == (configFile >> 'CfgWeapons' >> 'UavTerminal_base')" configClasses (configFile >> "CfgWeapons") apply {configName _x};
-private _gpsDevices = "getText (_x >> 'simulation') == 'ItemGPS'" configClasses (configFile >> "CfgWeapons") apply {configName _x};
-
-GVAR(gpsWhitelist) = _uavTerminals + _gpsDevices;
+// GPS whitelist (GPS devices + UAV terminals)
+GVAR(gpsWhitelist) = "getText (_x >> 'simulation') == 'ItemGPS' || inheritsFrom _x == (configFile >> 'CfgWeapons' >> 'UavTerminal_base')" configClasses (configFile >> "CfgWeapons") apply {configName _x};
 
 // some compasses have less then 360 degrees
 GVAR(oddDirectionCompasses) = [] call CBA_fnc_createNamespace;

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -120,8 +120,8 @@ private _curCat = localize "STR_dui_cat_compass";
     ,[localize "STR_dui_show_dir", localize "STR_dui_show_dir_desc"]
     ,[CBA_SETTINGS_CAT, _curCat]
     ,[
-        [0,1,2,3],
-        [localize "STR_dui_show_dir_opt1",localize "STR_dui_show_dir_opt2",localize "STR_dui_show_dir_opt3",localize "STR_dui_show_dir_opt4"],
+        [0,1,2,3,4],
+        [localize "STR_dui_show_dir_opt1",localize "STR_dui_show_dir_opt2",localize "STR_dui_show_dir_opt3",localize "STR_dui_show_dir_opt4",localize "STR_dui_show_dir_opt5"],
         1
     ]
     ,false

--- a/addons/radar/XEH_preInit.sqf
+++ b/addons/radar/XEH_preInit.sqf
@@ -19,6 +19,12 @@ GVAR(setNamelist) = true;
 // compass whitelist, these need to be lowercase!!
 GVAR(compassWhitelist) = "getText (_x >> 'simulation') == 'ItemCompass'" configClasses (configFile >> "CfgWeapons") apply {configName _x};
 
+// GPS whitelist
+private _uavTerminals = "inheritsFrom _x == (configFile >> 'CfgWeapons' >> 'UavTerminal_base')" configClasses (configFile >> "CfgWeapons") apply {configName _x};
+private _gpsDevices = "getText (_x >> 'simulation') == 'ItemGPS'" configClasses (configFile >> "CfgWeapons") apply {configName _x};
+
+GVAR(gpsWhitelist) = _uavTerminals + _gpsDevices;
+
 // some compasses have less then 360 degrees
 GVAR(oddDirectionCompasses) = [] call CBA_fnc_createNamespace;
 GVAR(oddDirectionCompasses) setVariable ["gm_ge_army_conat2", 6400];

--- a/addons/radar/functions/fnc_compassPFH.sqf
+++ b/addons/radar/functions/fnc_compassPFH.sqf
@@ -32,6 +32,7 @@ if ([_player] call EFUNC(main,canHudBeShown)) then {
     private _dir = _camDirVec call CBA_fnc_vectDir;
     // private _dir = (getCameraViewDirection _player) call CBA_fnc_vectDir;
     private _hasCompass = ([_player] call FUNC(getCompass)) isNotEqualTo "";
+    private _hasGPS = ([_player] call FUNC(getGPS)) isNotEqualTo "";
 
     _compassCtrl ctrlSetAngle [[0,-_dir] select _hasCompass, 0.5, 0.5, true];
 
@@ -40,7 +41,8 @@ if ([_player] call EFUNC(main,canHudBeShown)) then {
         {diwako_dui_enable_compass_dir isEqualTo 1 && {!(isNull objectParent _player)} ||
         {diwako_dui_enable_compass_dir isEqualTo 2} ||
         {diwako_dui_enable_compass_dir isEqualTo 3 && {private _veh = (vehicle _player); _veh isNotEqualTo _player && {(driver _veh) isEqualTo _player}}}
-        }}) then {
+        }} ||
+        _hasGPS && {diwako_dui_enable_compass_dir isEqualTo 4}) then {
         private _dirCalc = (round _dir) mod 360;
         private _maxDegrees = GVAR(maxDegrees);
         if (_maxDegrees isNotEqualTo 360) then {

--- a/addons/radar/functions/fnc_compassPFH.sqf
+++ b/addons/radar/functions/fnc_compassPFH.sqf
@@ -32,17 +32,16 @@ if ([_player] call EFUNC(main,canHudBeShown)) then {
     private _dir = _camDirVec call CBA_fnc_vectDir;
     // private _dir = (getCameraViewDirection _player) call CBA_fnc_vectDir;
     private _hasCompass = ([_player] call FUNC(getCompass)) isNotEqualTo "";
-    private _hasGPS = ([_player] call FUNC(getGPS)) isNotEqualTo "";
 
     _compassCtrl ctrlSetAngle [[0,-_dir] select _hasCompass, 0.5, 0.5, true];
 
     if (_hasCompass &&
-        {diwako_dui_enable_compass_dir in [1, 2, 3] &&
+        {diwako_dui_enable_compass_dir in [1, 2, 3, 4] &&
         {diwako_dui_enable_compass_dir isEqualTo 1 && {!(isNull objectParent _player)} ||
         {diwako_dui_enable_compass_dir isEqualTo 2} ||
-        {diwako_dui_enable_compass_dir isEqualTo 3 && {private _veh = (vehicle _player); _veh isNotEqualTo _player && {(driver _veh) isEqualTo _player}}}
-        }} ||
-        _hasGPS && {diwako_dui_enable_compass_dir isEqualTo 4}) then {
+        {diwako_dui_enable_compass_dir isEqualTo 3 && {private _veh = (vehicle _player); _veh isNotEqualTo _player && {(driver _veh) isEqualTo _player}}} || 
+        {diwako_dui_enable_compass_dir isEqualTo 4 && {([_player] call FUNC(getGPS)) isNotEqualTo ""}}
+        }}) then {
         private _dirCalc = (round _dir) mod 360;
         private _maxDegrees = GVAR(maxDegrees);
         if (_maxDegrees isNotEqualTo 360) then {

--- a/addons/radar/functions/fnc_getCompass.sqf
+++ b/addons/radar/functions/fnc_getCompass.sqf
@@ -2,7 +2,4 @@
 params ["_unit"];
 
 private _array = (assignedItems _unit) arrayIntersect GVAR(compassWhitelist);
-if (_array isNotEqualTo []) exitWith {
-    _array select 0
-};
-""
+_array param [0, ""];

--- a/addons/radar/functions/fnc_getGPS.sqf
+++ b/addons/radar/functions/fnc_getGPS.sqf
@@ -1,0 +1,8 @@
+#include "script_component.hpp"
+params ["_unit"];
+
+private _array = (assignedItems _unit) arrayIntersect GVAR(gpsWhitelist);
+if (_array isNotEqualTo []) exitWith {
+    _array select 0
+};
+""

--- a/addons/radar/functions/fnc_getGPS.sqf
+++ b/addons/radar/functions/fnc_getGPS.sqf
@@ -2,7 +2,4 @@
 params ["_unit"];
 
 private _array = (assignedItems _unit) arrayIntersect GVAR(gpsWhitelist);
-if (_array isNotEqualTo []) exitWith {
-    _array select 0
-};
-""
+_array param [0, ""];


### PR DESCRIPTION
**When merged this pull request will:**
 - Add a new option to the "Show Bearing" options in the CBA settings.
 - Show the bearing above the compass only if the player has a GPS device or UAV terminal.