### PR TITLE
Fixed nametag display inconsistency

### DIFF
--- a/addons/nametags/functions/fnc_onDraw.sqf
+++ b/addons/nametags/functions/fnc_onDraw.sqf
@@ -9,6 +9,9 @@ if ((ctrlPosition _ctrl) isNotEqualTo _pos) then {
 };
 
 private _target = cursorObject;
+private _skipVicCheck = (netId _target) isEqualTo "1:0"; // only ever true when cursorObject returns the weapon of a
+// unit, per the comment from Pierre MGI at https://community.bistudio.com/wiki/cursorObject
+// we'd like to find the cursorObject regardless, so we piggyback on the LIS check to find the most probable one
 private _player = call CBA_fnc_currentUnit;
 
 if (GVAR(useLIS)) then {
@@ -25,7 +28,7 @@ if (GVAR(useLIS)) then {
         _x params ["", "", "_obj"];
         if (_obj isKindOf "CAManBase" &&
            {_obj isNotEqualTo _player &&
-           {!isNull (objectParent _obj)
+           {!isNull (objectParent _obj) || {_skipVicCheck}
         }}) then {
             _target = _obj;
             break;

--- a/addons/nametags/functions/fnc_onDraw.sqf
+++ b/addons/nametags/functions/fnc_onDraw.sqf
@@ -9,12 +9,13 @@ if ((ctrlPosition _ctrl) isNotEqualTo _pos) then {
 };
 
 private _target = cursorObject;
-private _skipVicCheck = (netId _target) isEqualTo "1:0"; // only ever true when cursorObject returns the weapon of a
-// unit, per the comment from Pierre MGI at https://community.bistudio.com/wiki/cursorObject
-// we'd like to find the cursorObject regardless, so we piggyback on the LIS check to find the most probable one
 private _player = call CBA_fnc_currentUnit;
 
 if (GVAR(useLIS)) then {
+    private _skipVicCheck = (netId _target) isEqualTo "1:0"; // only ever true when cursorObject returns the weapon of a
+    // unit, per the comment from Pierre MGI at https://community.bistudio.com/wiki/cursorObject
+    // we'd like to find the cursorObject regardless, so we piggyback on the LIS check to find the most probable one
+    
     private _lis = lineIntersectsSurfaces [
         AGLToASL positionCameraToWorld [0, 0, 0],
         AGLToASL positionCameraToWorld [0, 0, GVAR(renderDistance) + 1],


### PR DESCRIPTION
The `cursorObject` command will return an object representing the weapon a player is holding (or the launcher on their back) if you point at that when `cursorObject` is queried. This change piggybacks off of the new LIS check functionality in order to find what the `cursorObject` likely would have been, as there's no way to get from the weapon object to the unit who's holding it. See screenshots.

https://i.imgur.com/5MJPV4F.jpg
https://i.imgur.com/Uomn6Z3.jpeg