### PR TITLE
Fix incorrect blue color on radar for diwako_dui_colors >> tritanomaly

### DIFF
--- a/addons/main/CfgColorStyles.hpp
+++ b/addons/main/CfgColorStyles.hpp
@@ -105,7 +105,7 @@ class diwako_dui_colors {
         white = "#FFFFFF";
         red = "#DE0000";
         green = "#079625";
-        blue = "#3369dA";
+        blue = "#3369DA";
         yellow = "#D99F28";
     };
 

--- a/addons/main/include/getColorStyles.sqf
+++ b/addons/main/include/getColorStyles.sqf
@@ -12,7 +12,7 @@ private _colorIdent = [];
 
 private _getColorFromHex = {
     params ["_key", "_hex"];
-    _hex = toArray _hex;
+    _hex = toArray toUpper _hex;
     _hex deleteAt 0; //remove the '#' at the beginning
     private _nums = toArray "0123456789ABCDEF"; //for converting hex nibbles to base 10 equivalents
 


### PR DESCRIPTION
When using the tritanomaly color scheme the blue icon on the radar is colored differently than the blue text. If you assign a unit to the blue team and get the compass color assigned to the unit ( `_unit getVariable "diwako_dui_main_compass_color"`) it returns `[0.2,0.411765,-0.0235294]`.

The blue config hex value for `diwako_dui_colors >> tritanomaly` contains a lowercase 'd'. This causes an issue with `_getColorFromHex` when converting from hex to an RGB value in the range of [0, 1] because the function expects the incoming hex string to only have values 0-9 or A-F. The 'd' cannot be found in `_nums` and thus ` _b = -1 * 16 + 10 == -6`, and then divided by 255 to produce the value -0.0235294. The negative value is then treated as zero when used by `drawIcon3D`.

These changes fix the aforementioned config value and adds `toUpper` to `_getColorFromHex`, in case a lowercase letter slips into another hex value in the future.