### PR TITLE
Fix "Show Only When Compass is Available" setting

### DIFF
--- a/addons/linecompass/functions/fnc_cacheLoop.sqf
+++ b/addons/linecompass/functions/fnc_cacheLoop.sqf
@@ -4,7 +4,7 @@
 
 private _player = call CBA_fnc_currentUnit;
 
-private _shouldShowCompass = GVAR(Enabled) && { [_player] call EFUNC(main,canHudBeShown) } && { GVAR(CompassAvailableShown) && [_player] call EFUNC(main,getCompass) isNotEqualTo "" };
+private _shouldShowCompass = GVAR(Enabled) && { [_player] call EFUNC(main,canHudBeShown) } && { GVAR(CompassAvailableShown) && [_player] call EFUNC(main,getCompass) isNotEqualTo "" || !GVAR(CompassAvailableShown)};
 
 if (!_shouldShowCompass) exitWith {
     if (GVAR(CompassShown)) then {

--- a/addons/linecompass/script_component.hpp
+++ b/addons/linecompass/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\diwako_dui\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 
 #ifdef DEBUG_ENABLED_LINECOMPASS
     #define DEBUG_MODE_FULL

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -12,8 +12,7 @@ private _curCat = localize "STR_dui_cat_general";
     {
         params ["_value"];
         if (_value) then { call FUNC(showCompass); };
-    },
-    false
+    }
 ] call CBA_fnc_addSetting;
 
 [
@@ -21,9 +20,6 @@ private _curCat = localize "STR_dui_cat_general";
     "CHECKBOX",
     "STR_dui_linecompass_compass_required",
     [_cat, _curCat],
-    true,
-    1,
-    {},
     true
 ] call CBA_fnc_addSetting;
 
@@ -124,7 +120,6 @@ private _tfar = isClass (configFile >> "CfgPatches" >> "task_force_radio");
 private _acre = isClass (configFile >> "CfgPatches" >> "acre_main");
 
 if (_acre || _tfar) then {
-
     [
         QGVAR(showSpeaking),
         "CHECKBOX",
@@ -133,9 +128,6 @@ if (_acre || _tfar) then {
         true,
         false
     ] call CBA_fnc_addSetting;
-
 } else {
-
     GVAR(showSpeaking) = false;
-
 };

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 12
-#define PATCHLVL 0
+#define PATCHLVL 1
 #define BUILD 0


### PR DESCRIPTION
Disabling the setting just meant the compass is not shown what so ever.