### PR TITLE
Line Compass - Add Limit Drawn Detail Setting

### DIFF
--- a/addons/linecompass/functions/fnc_onDraw.sqf
+++ b/addons/linecompass/functions/fnc_onDraw.sqf
@@ -45,7 +45,7 @@ for "_i" from 0 to 13 do {
     private _newAlpha = (_i * 15 + _bearingOffset) call FUNC(getAlphaFromX);
     private _oldAlpha = GVAR(bearingAlphaCache) select _idc;
 
-    switch (GVAR(DrawBearing)) do {
+    switch (GVAR(ResolvedDrawBearing)) do {
         case 0: {
             _newAlpha = 0;
         };

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -29,13 +29,16 @@ private _curCat = localize "STR_dui_cat_general";
     "STR_dui_linecompass_draw_directions",
     [_cat, _curCat],
     [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2],
-    0, {
-    GVAR(ResolvedDrawBearing) = if (isNil QGVAR(AllowedDrawBearing)) then {
-        GVAR(DrawBearing)
-    } else {
-        GVAR(AllowedDrawBearing) min GVAR(DrawBearing)
+    0,
+    {
+        params ["_value"];
+        GVAR(ResolvedDrawBearing) = if (isNil QGVAR(AllowedDrawBearing)) then {
+            _value
+        } else {
+            GVAR(AllowedDrawBearing) min _value
+        };
     }
-}] call CBA_fnc_addSetting;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(AllowedDrawBearing),
@@ -43,13 +46,16 @@ private _curCat = localize "STR_dui_cat_general";
     ["STR_dui_linecompass_allowed_draw_directions", "STR_dui_linecompass_allowed_draw_directions_desc"],
     [_cat, _curCat],
     [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2],
-    1, {
-    GVAR(ResolvedDrawBearing) = if (isNil QGVAR(DrawBearing)) then {
-        GVAR(AllowedDrawBearing)
-    } else {
-        GVAR(AllowedDrawBearing) min GVAR(DrawBearing)
+    1,
+    {
+        params ["_value"];
+        GVAR(ResolvedDrawBearing) = if (isNil QGVAR(DrawBearing)) then {
+            _value
+        } else {
+            GVAR(DrawBearing) min _value
+        };
     }
-}] call CBA_fnc_addSetting;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(IconOutline),

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -28,8 +28,28 @@ private _curCat = localize "STR_dui_cat_general";
     "LIST",
     "STR_dui_linecompass_draw_directions",
     [_cat, _curCat],
-    [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2]
-] call CBA_fnc_addSetting;
+    [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2],
+    0, {
+    GVAR(ResolvedDrawBearing) = if (isNil QGVAR(AllowedDrawBearing)) then {
+        GVAR(DrawBearing)
+    } else {
+        GVAR(AllowedDrawBearing) min GVAR(DrawBearing)
+    }
+}] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AllowedDrawBearing),
+    "LIST",
+    ["STR_dui_linecompass_allowed_draw_directions", "STR_dui_linecompass_allowed_draw_directions_desc"],
+    [_cat, _curCat],
+    [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2],
+    1, {
+    GVAR(ResolvedDrawBearing) = if (isNil QGVAR(DrawBearing)) then {
+        GVAR(AllowedDrawBearing)
+    } else {
+        GVAR(AllowedDrawBearing) min GVAR(DrawBearing)
+    }
+}] call CBA_fnc_addSetting;
 
 [
     QGVAR(IconOutline),

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -32,27 +32,25 @@ private _curCat = localize "STR_dui_cat_general";
     0,
     {
         params ["_value"];
-        GVAR(ResolvedDrawBearing) = if (isNil QGVAR(AllowedDrawBearing)) then {
-            _value
+        GVAR(ResolvedDrawBearing) = if (!isNil QGVAR(AllowNumericDrawBearing) && {!GVAR(AllowNumericDrawBearing)}) then {
+            _value min 1
         } else {
-            GVAR(AllowedDrawBearing) min _value
+            _value
         };
     }
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(AllowedDrawBearing),
-    "LIST",
+    QGVAR(AllowNumericDrawBearing),
+    "CHECKBOX",
     ["STR_dui_linecompass_allowed_draw_directions", "STR_dui_linecompass_allowed_draw_directions_desc"],
     [_cat, _curCat],
-    [[0, 1, 2], ["STR_dui_linecompass_draw_bearings_none", "STR_dui_linecompass_draw_bearings_bearings", "STR_dui_linecompass_draw_bearings_all"], 2],
+    true,
     1,
     {
         params ["_value"];
-        GVAR(ResolvedDrawBearing) = if (isNil QGVAR(DrawBearing)) then {
-            _value
-        } else {
-            GVAR(DrawBearing) min _value
+        GVAR(ResolvedDrawBearing) = if (!isNil QGVAR(DrawBearing) && !_value) then {
+            GVAR(DrawBearing) min 1
         };
     }
 ] call CBA_fnc_addSetting;

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -61,7 +61,7 @@
                 <French>Aucun</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_bearings">
-                <English>8-point compass</English>
+                <English>8-point Compass</English>
                 <French>Points cardinaux</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_all">

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -7,10 +7,10 @@
                 <French>Boussole linéaire</French>
             </Key>
             <Key ID="STR_dui_linecompass_allowed_draw_directions">
-                <English>Direction Drawn Limit</English>
+                <English>Allow Numeric Directions Drawn</English>
             </Key>
             <Key ID="STR_dui_linecompass_allowed_draw_directions_desc">
-                <English>Limits the detail of the line compass bearing per mission or serverside while allowing player choice of simpler options</English>
+                <English>Allow the display of numeric bearings along the line compass.</English>
             </Key>
             <Key ID="STR_dui_linecompass_enabled">
                 <English>Enabled</English>

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -10,7 +10,7 @@
                 <English>Direction Drawn Limit</English>
             </Key>
             <Key ID="STR_dui_linecompass_allowed_draw_directions_desc">
-                <English>Limits the detail of the line compass bearings while allowing choices between simpler options</English>
+                <English>Limits the detail of the line compass bearings while allowing player choice of simpler options</English>
             </Key>
             <Key ID="STR_dui_linecompass_enabled">
                 <English>Enabled</English>

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -61,7 +61,7 @@
                 <French>Aucun</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_bearings">
-                <English>8-point Compass</English>
+                <English>Cardinal and Ordinal</English>
                 <French>Points cardinaux</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_all">

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -61,7 +61,7 @@
                 <French>Aucun</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_bearings">
-                <English>Cardinal and Ordinal</English>
+                <English>Only Cardinal and Ordinal</English>
                 <French>Points cardinaux</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_all">

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -6,6 +6,12 @@
                 <English>Line Compass</English>
                 <French>Boussole linéaire</French>
             </Key>
+            <Key ID="STR_dui_linecompass_allowed_draw_directions">
+                <English>Direction Drawn Limit</English>
+            </Key>
+            <Key ID="STR_dui_linecompass_allowed_draw_directions_desc">
+                <English>Limits the detail of the line compass bearings while allowing choices between simpler options</English>
+            </Key>
             <Key ID="STR_dui_linecompass_enabled">
                 <English>Enabled</English>
                 <French>Activé</French>

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -10,7 +10,7 @@
                 <English>Direction Drawn Limit</English>
             </Key>
             <Key ID="STR_dui_linecompass_allowed_draw_directions_desc">
-                <English>Limits the detail of the line compass bearings while allowing player choice of simpler options</English>
+                <English>Limits the detail of the line compass bearing per mission or serverside while allowing player choice of simpler options</English>
             </Key>
             <Key ID="STR_dui_linecompass_enabled">
                 <English>Enabled</English>

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -61,7 +61,7 @@
                 <French>Aucun</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_bearings">
-                <English>Quarter Bearings</English>
+                <English>8-point compass</English>
                 <French>Points cardinaux</French>
             </Key>
             <Key ID="STR_dui_linecompass_draw_bearings_all">


### PR DESCRIPTION
## This PR will:
- Add an option to limit the amount of detail a player can choose for bearings on their line compass
  - This allows for servers or missions to limit players ability to players to choose detail independently while limiting options deemed too precise

https://github.com/user-attachments/assets/87473e02-6c2a-4d58-9a1e-1d3ef47adf95

## Feedback requested:
- ~~Would this be better as a checkbox option for allowing the "ALL" bearing option (essentially what this PR boils down to)?~~ Done
- Is the setting description clear?