### PR TITLE
 Line Compass - Add Setting to Control Showing Custom Waypoint on Line Compass

### DIFF
--- a/addons/linecompass/functions/fnc_cacheLoop.sqf
+++ b/addons/linecompass/functions/fnc_cacheLoop.sqf
@@ -18,7 +18,7 @@ if (_shouldShowCompass) then {
     };
 };
 
-if (customWaypointPosition isNotEqualTo GVAR(customWaypointPosition)) then {
+if (customWaypointPosition isNotEqualTo GVAR(customWaypointPosition) && GVAR(enableShowCustomWP)) then {
     if (customWaypointPosition isEqualTo []) then {
         "CUSTOM_WAYPOINT_POSITION" call FUNC(removeLineMarker);
     } else {

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -143,7 +143,7 @@ if (isClass(configFile >> "CfgPatches" >> "ace_finger")) then {
 [
     QGVAR(enableShowCustomWP),
     "CHECKBOX",
-    ["STR_dui_show_custom_waypoint", "STR_dui_show_custom_waypoint_desc"],
+    ["STR_dui_linecompass_show_custom_waypoint", "STR_dui_linecompass_show_custom_waypoint_desc"],
     [_cat, _curCat],
     true,
     0,

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -140,6 +140,24 @@ if (isClass(configFile >> "CfgPatches" >> "ace_finger")) then {
     false
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(enableShowCustomWP),
+    "CHECKBOX",
+    ["STR_dui_show_custom_waypoint", "STR_dui_show_custom_waypoint_desc"],
+    [_cat, _curCat],
+    true,
+    0,
+    {
+        params ["_value"];
+        if (_value) then {
+            ["CUSTOM_WAYPOINT_POSITION", customWaypointPosition, GVAR(CustomWaypointColor)] call FUNC(addLineMarker);
+            GVAR(customWaypointPosition) = customWaypointPosition;
+        } else {
+            "CUSTOM_WAYPOINT_POSITION" call FUNC(removeLineMarker);
+        };
+    }
+] call CBA_fnc_addSetting;
+
 private _tfar = isClass (configFile >> "CfgPatches" >> "task_force_radio");
 private _acre = isClass (configFile >> "CfgPatches" >> "acre_main");
 

--- a/addons/linecompass/settings.inc.sqf
+++ b/addons/linecompass/settings.inc.sqf
@@ -149,7 +149,7 @@ if (isClass(configFile >> "CfgPatches" >> "ace_finger")) then {
     0,
     {
         params ["_value"];
-        if (_value) then {
+        if (_value && customWaypointPosition isNotEqualTo []) then {
             ["CUSTOM_WAYPOINT_POSITION", customWaypointPosition, GVAR(CustomWaypointColor)] call FUNC(addLineMarker);
             GVAR(customWaypointPosition) = customWaypointPosition;
         } else {

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -100,6 +100,12 @@
                 <French>Élément de l'UI de la Boussole linéaire, faites-la glisser et déposez-la pour la repositionner. Vous pouvez réinitialiser la position dans les paramètres de l'ABC si quelque chose ne va pas !</French>
                 <German>Linien-Kompass UI Element, mit der Maus an gewünschte Position ziehen. Die Position kann durch CBA Einstellungen auf den Standard zurückgesetzt werden!</German>
             </Key>
+            <Key ID="STR_dui_show_custom_waypoint">
+                <English>Show Custom Waypoint</English>
+            </Key>
+            <Key ID="STR_dui_show_custom_waypoint_desc">
+                <English>Show custom waypoint (default shift + left click) on the line compass</English>
+            </Key>
             <Key ID="STR_dui_linecompass_show_speaking">
                 <English>Show icon when units speak</English>
                 <French>Afficher l'icône lorsque les unités parlent</French>

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -100,10 +100,10 @@
                 <French>Élément de l'UI de la Boussole linéaire, faites-la glisser et déposez-la pour la repositionner. Vous pouvez réinitialiser la position dans les paramètres de l'ABC si quelque chose ne va pas !</French>
                 <German>Linien-Kompass UI Element, mit der Maus an gewünschte Position ziehen. Die Position kann durch CBA Einstellungen auf den Standard zurückgesetzt werden!</German>
             </Key>
-            <Key ID="STR_dui_show_custom_waypoint">
+            <Key ID="STR_dui_linecompass_show_custom_waypoint">
                 <English>Show Custom Waypoint</English>
             </Key>
-            <Key ID="STR_dui_show_custom_waypoint_desc">
+            <Key ID="STR_dui_linecompass_show_custom_waypoint_desc">
                 <English>Show custom waypoint (default set by shift + left clicking on the map) on the line compass.</English>
             </Key>
             <Key ID="STR_dui_linecompass_show_speaking">

--- a/addons/linecompass/stringtable.xml
+++ b/addons/linecompass/stringtable.xml
@@ -104,7 +104,7 @@
                 <English>Show Custom Waypoint</English>
             </Key>
             <Key ID="STR_dui_show_custom_waypoint_desc">
-                <English>Show custom waypoint (default shift + left click) on the line compass</English>
+                <English>Show custom waypoint (default set by shift + left clicking on the map) on the line compass.</English>
             </Key>
             <Key ID="STR_dui_linecompass_show_speaking">
                 <English>Show icon when units speak</English>


### PR DESCRIPTION
## This PR will
Add checkbox (default on) to enable or disable displaying `customWaypointPosition` on the line compass.