### PR TITLE
Use sorted name list for drawing icons

### DIFF
--- a/addons/radar/functions/fnc_cacheLoop.sqf
+++ b/addons/radar/functions/fnc_cacheLoop.sqf
@@ -25,6 +25,8 @@ if (diwako_dui_compass_hide_blip_alone_group && _isAloneInGroup) then {
     _group = [];
 };
 
+_group = [_group, _player] call FUNC(sortNameList);
+
 if (GVAR(group_by_vehicle)) then {
     private _newGrp = _group apply { [objectParent _x, parseNumber ((driver vehicle _x) isNotEqualTo _x), _x] };
     _newGrp sort true;
@@ -217,8 +219,6 @@ if (_isAloneInGroup) exitWith {
 if !(ctrlShown _grpCtrl) then {
     _grpCtrl ctrlShow true;
 };
-
-_group = [_group, _player] call FUNC(sortNameList);
 
 private _text = "";
 private _curList = controlNull;


### PR DESCRIPTION
My group uses custom sorting to filter people out from the name list, but their icons still get drawn on the radar. 

This change makes it so that any edits to the group done by a custom sort function are used when drawing icons. So any removals or additions to the name list are matched by the compass.

This works fine with grouping by vehicles and with special tracked units.

Could be a CBA option in case some group likes the current behavior but I don't know how translation happens here. 